### PR TITLE
fix: 홈 아이템의 향표기 Chip 부분 상단 컴포넌트와의 마진값 조절

### DIFF
--- a/app/src/main/java/com/ddd4/synesthesia/beer/util/BindingAdapter.kt
+++ b/app/src/main/java/com/ddd4/synesthesia/beer/util/BindingAdapter.kt
@@ -32,6 +32,7 @@ fun makeChips(chipGroup: ChipGroup, flavor: List<String>) {
         val chip = Chip(chipGroup.context).apply {
             setChipDrawable(ChipDrawable.createFromResource(this.context, R.xml.chip_home_item))
             setTextColor(resources.getColor(R.color.black, null))
+            ensureAccessibleTouchTarget(20.dp)
             textSize = 12f
             typeface = ResourcesCompat.getFont(chipGroup.context, R.font.notosans_kr_bold)
             text = it

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -133,9 +133,8 @@
         <HorizontalScrollView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_8"
             android:scrollbars="none"
-            android:layout_marginTop="8dp"
-            app:layout_constraintBottom_toBottomOf="@id/iv_beer_thumbnail"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/tv_beer_style"
             app:layout_constraintTop_toBottomOf="@id/tv_beer_country">


### PR DESCRIPTION
홈 리사이클러뷰에 표기되는 Chip 의 상단 패딩 값 부분 수정 했습니다.

이상하게 에뮬레이터랑 실기기랑 다르게 표기되서 조금 헷갈렸네요 ㅎㅎ