### PR TITLE
fix: 향 데이터 없을 경우 태그 표시 제거하도록 수정 (#74)

### DIFF
--- a/app/src/main/java/com/ddd4/synesthesia/beer/util/BindingAdapter.kt
+++ b/app/src/main/java/com/ddd4/synesthesia/beer/util/BindingAdapter.kt
@@ -30,8 +30,11 @@ import com.google.android.material.chip.ChipGroup
 
 @BindingAdapter("app:addChip")
 fun makeChips(chipGroup: ChipGroup, flavor: List<String>?) {
+    if (flavor == null) return
     chipGroup.removeAllViews()
-    flavor?.asSequence()?.forEach {
+    if (flavor.first().isEmpty()) chipGroup.visibility = View.GONE else chipGroup.visibility = View.VISIBLE
+
+    flavor.asSequence().forEach {
         val chip = Chip(chipGroup.context).apply {
             setChipDrawable(ChipDrawable.createFromResource(this.context, R.xml.chip_home_item))
             setTextColor(resources.getColor(R.color.black, null))


### PR DESCRIPTION
closed #74 

향 데이터 없을 경우 하단 태그 부분 보이지 않도록 처리 했습니다.